### PR TITLE
Disables the manga button when no manga is found

### DIFF
--- a/cogs/anime/media_list.py
+++ b/cogs/anime/media_list.py
@@ -151,6 +151,9 @@ class MediaList(Paginator[discord.Embed]):
 
         if self.manga is None:
             self.manga = await self.fetch_manga()
+            if not self.manga:
+                button.disabled = True
+                await self.update(interaction)
 
             button.label = f"Manga ({self.get_length(self.manga)})"
 

--- a/cogs/anime/media_list.py
+++ b/cogs/anime/media_list.py
@@ -155,7 +155,7 @@ class MediaList(Paginator[discord.Embed]):
             if not self.manga["lists"]:
                 self._anime.disabled = True
                 await self.update(interaction)
-                return
+                return await self.update(interaction)
 
             button.label = f"Manga ({self.get_length(self.manga)})"
 

--- a/cogs/anime/media_list.py
+++ b/cogs/anime/media_list.py
@@ -135,7 +135,8 @@ class MediaList(Paginator[discord.Embed]):
 
     @ui.button(emoji="\N{VIDEO CAMERA}", label="Anime", row=2, disabled=True, style=discord.ButtonStyle.green)
     async def _anime(self, interaction: Interaction, button: ui.Button[Self]):
-        self._manga.disabled = False
+        if self.manga is not None:
+            self._manga.disabled = False
         button.disabled = True
 
         self.collection = self.anime
@@ -151,9 +152,10 @@ class MediaList(Paginator[discord.Embed]):
 
         if self.manga is None:
             self.manga = await self.fetch_manga()
-            if not self.manga:
-                button.disabled = True
+            if not self.manga["lists"]:
+                self._anime.disabled = True
                 await self.update(interaction)
+                return
 
             button.label = f"Manga ({self.get_length(self.manga)})"
 

--- a/cogs/anime/media_list.py
+++ b/cogs/anime/media_list.py
@@ -154,7 +154,6 @@ class MediaList(Paginator[discord.Embed]):
             self.manga = await self.fetch_manga()
             if not self.manga["lists"]:
                 self._anime.disabled = True
-                await self.update(interaction)
                 return await self.update(interaction)
 
             button.label = f"Manga ({self.get_length(self.manga)})"


### PR DESCRIPTION
This change disables the `manga` button in `anilist list` command when it receives no manga from the API for the user. Previously, this would change the view values leading them to incorrectly attempt to browse through them.