### PR TITLE
Add next ep text to anilist list

### DIFF
--- a/cogs/anime/client.py
+++ b/cogs/anime/client.py
@@ -245,6 +245,7 @@ MEDIA_LIST_FRAGMENT = """
                     ...listEntry
                     nextAiringEpisode {
                     episode
+                    airingAt
                     }
                 }
             }

--- a/cogs/anime/media_list.py
+++ b/cogs/anime/media_list.py
@@ -120,19 +120,24 @@ class MediaList(Paginator[discord.Embed]):
                 url = f"https://anilist.co/{(media['type']).lower()}/{media['id']}"
 
                 backlog_text = ""
-                if (
-                    (next_episode := media["nextAiringEpisode"])
-                    and next_episode
-                    and entry["progress"]
-                    and (entry["status"] in (MediaListStatus.CURRENT, MediaListStatus.REPEATING))
-                ):
+                if (next_episode := media["nextAiringEpisode"]) and next_episode and entry["progress"]:
                     current_ep = next_episode["episode"] - 1
                     episode_backlog = current_ep - entry["progress"]
+
                     plural = "s" if episode_backlog > 1 else ""
-                    backlog_text = f"`({episode_backlog} episode{plural} behind)`" if episode_backlog else ""
+
+                    backlog_text = (
+                        (f"`({episode_backlog} episode{plural} behind)`")
+                        if episode_backlog and (entry["status"] in (MediaListStatus.CURRENT, MediaListStatus.REPEATING))
+                        else ""
+                    )
+
+                    backlog_text += (
+                        f"\n-# ╰ Next episode <t:{next_episode['airingAt']}:R> (<t:{next_episode['airingAt']}:f>)"
+                    )
 
                 wording = "Rewatches" if format == MediaType.ANIME else "Rereads"
-                print("entry", entry)
+
                 info = field(
                     f"### [{title}]({url})",
                     f"↪ Score: **{get_score(entry['score'], score_format)}**",

--- a/cogs/anime/types.py
+++ b/cogs/anime/types.py
@@ -156,6 +156,7 @@ class FollowingStatus(TypedDict):
 
 class AiringSchedule(TypedDict):
     episode: int
+    airingAt: int
 
 
 class MediaList(TypedDict):


### PR DESCRIPTION
This PR adds a "Next episode [in x days] (insert date here)" text to anilist list command.
This text is visible if the series is releasing as it would have its nextAiring data. 

Code-wise the backlog text is now the only thing under a check for CURRENT or REWATCHING while the actual if block is just if the data is there.